### PR TITLE
Handle "collection-agent" argument as Datadog agent URL

### DIFF
--- a/cli_flags.go
+++ b/cli_flags.go
@@ -33,7 +33,7 @@ const (
 	defaultProbabilisticThreshold    = tracer.ProbabilisticThresholdMax
 	defaultProbabilisticInterval     = 1 * time.Minute
 	defaultArgSendErrorFrames        = false
-	defaultArgCollAgentAddr          = "http://localhost:8126/profiling/v1/input"
+	defaultArgCollAgentAddr          = "http://localhost:8126"
 
 	// This is the X in 2^(n + x) where n is the default hardcoded map size value
 	defaultArgMapScaleFactor = 0


### PR DESCRIPTION
`collection-agent` is treated as the Datadog agent URL and profiling endpoint is appended to it.
