### PR TITLE
Improve build image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ARG arch=amd64
 
 RUN apt-get update -y && apt-get dist-upgrade -y && apt-get install -y \
     curl wget cmake dwz lsb-release software-properties-common gnupg git clang llvm \
-    golang unzip
+    golang unzip sudo
 
 RUN git clone --depth 1 --branch v3.1.0 --recursive https://github.com/zyantific/zydis.git && \
     cd zydis && mkdir build && cd build && \
@@ -38,6 +38,8 @@ RUN mv /root/go/bin/* /usr/local/bin/
 
 ENV GOCACHE=/agent/.cache
 
-RUN echo "export PATH=\"\$PATH:\$(go env GOPATH)/bin\"" >> ~/.bashrc
+RUN useradd -ms /bin/bash build
+RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+RUN adduser build sudo
 
-ENTRYPOINT ["/bin/bash", "-l", "-c"]
+USER build

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,6 @@ RUN                                                                             
 # The docker image is built as root - make binaries available to user.
 RUN mv /root/go/bin/* /usr/local/bin/
 
-ENV GOPATH=/agent/go
 ENV GOCACHE=/agent/.cache
 
 RUN echo "export PATH=\"\$PATH:\$(go env GOPATH)/bin\"" >> ~/.bashrc


### PR DESCRIPTION
* Avoid setting GOPATH in docker image
	Setting GOPATH to point inside agent directory has some undesirable side effects, such as make `go test ./...` fail ( because it tries to execute tests in ./go directory).
* Add a `build` user
    Add a `build` user  and run container with this user by default.
    This allows mounting local agent directory in the docker container while still the right uid permissions.
    Allow this user to sudo in order to run the otel agent.