### PR TITLE
Add root frame with executable path when available (PROF-9924)

### DIFF
--- a/libpf/libpf.go
+++ b/libpf/libpf.go
@@ -476,6 +476,7 @@ type TraceAndCounts struct {
 	Comm          string
 	PodName       string
 	ContainerName string
+	PID           PID
 }
 
 type FrameMetadata struct {

--- a/libpf/process/coredump.go
+++ b/libpf/process/coredump.go
@@ -282,6 +282,13 @@ func (cd *CoredumpProcess) GetMappingFile(_ *Mapping) string {
 	return ""
 }
 
+func (cd *CoredumpProcess) GetExecutablePath() (string, error) {
+	if cd.MainExecutable() == "" {
+		return "", errors.New("no main executable found")
+	}
+	return cd.MainExecutable(), nil
+}
+
 // CalculateMappingFileID implements the Process interface
 func (cd *CoredumpProcess) CalculateMappingFileID(m *Mapping) (libpf.FileID, error) {
 	// It is not possible to calculate the real FileID as the section headers

--- a/libpf/process/process.go
+++ b/libpf/process/process.go
@@ -166,6 +166,10 @@ func (sp *systemProcess) GetThreads() ([]ThreadInfo, error) {
 	return nil, errors.New("not implemented")
 }
 
+func (sp *systemProcess) GetExecutablePath() (string, error) {
+	return os.Readlink(fmt.Sprintf("/proc/%d/exe", sp.pid))
+}
+
 func (sp *systemProcess) Close() error {
 	return nil
 }

--- a/libpf/process/types.go
+++ b/libpf/process/types.go
@@ -105,6 +105,9 @@ type Process interface {
 	// GetMapping reads and parses process memory mappings
 	GetMappings() ([]Mapping, error)
 
+	// GetExecutablePath returns the path to the executable of the process
+	GetExecutablePath() (string, error)
+
 	// GetThread reads the process thread states
 	GetThreads() ([]ThreadInfo, error)
 

--- a/processmanager/manager_test.go
+++ b/processmanager/manager_test.go
@@ -63,6 +63,8 @@ func (d *dummyProcess) GetMappingFile(_ *process.Mapping) string {
 	return ""
 }
 
+func (d *dummyProcess) GetExecutablePath() (string, error) { return "", nil }
+
 func (d *dummyProcess) CalculateMappingFileID(m *process.Mapping) (libpf.FileID, error) {
 	return pfelf.CalculateID(m.Path)
 }

--- a/processmanager/processinfo.go
+++ b/processmanager/processinfo.go
@@ -614,6 +614,9 @@ func (pm *ProcessManager) SynchronizeProcess(pr process.Process) {
 		// Also see: Unified PID Events design doc
 		pm.ebpf.RemoveReportedPID(pid)
 	}
+
+	execPath, _ := pr.GetExecutablePath()
+	pm.reporter.ProcessMetadata(context.TODO(), pid, execPath)
 }
 
 // CleanupPIDs executes a periodic synchronization of pidToProcessInfo table with system processes.

--- a/reporter/datadog_reporter.go
+++ b/reporter/datadog_reporter.go
@@ -9,6 +9,7 @@ package reporter
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"net/url"
 	"os"
 	"path"
@@ -600,6 +601,10 @@ func addTraceLabels(labels map[string][]string, i traceInfo) {
 
 	if i.apmServiceName != "" {
 		labels["apmServiceName"] = append(labels["apmServiceName"], i.apmServiceName)
+	}
+
+	if i.pid != 0 {
+		labels["process_id"] = append(labels["process_id"], fmt.Sprintf("%d", i.pid))
 	}
 }
 

--- a/reporter/datadog_reporter.go
+++ b/reporter/datadog_reporter.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"net/url"
 	"os"
+	"path"
 	"strings"
 	"time"
 
@@ -536,8 +537,9 @@ func (r *DatadogReporter) getPprofProfile() (profile *pprofile.Profile,
 		}
 
 		if execPath != "" {
+			base := path.Base(execPath)
 			loc := createPProfLocation(profile, 0)
-			m := createPprofFunctionEntry(funcMap, profile, "", execPath)
+			m := createPprofFunctionEntry(funcMap, profile, base, execPath)
 			loc.Line = append(loc.Line, pprofile.Line{Function: m})
 			sample.Location = append(sample.Location, loc)
 		}

--- a/reporter/iface.go
+++ b/reporter/iface.go
@@ -48,7 +48,7 @@ type TraceReporter interface {
 	// ReportCountForTrace accepts a hash of a trace with a corresponding count and
 	// caches this information before a periodic reporting to the backend.
 	ReportCountForTrace(traceHash libpf.TraceHash, timestamp libpf.UnixTime32,
-		count uint16, comm, podName, containerName string)
+		count uint16, comm, podName, containerName string, pid libpf.PID)
 }
 
 type SymbolReporter interface {
@@ -63,6 +63,10 @@ type SymbolReporter interface {
 	// a periodic reporting to the backend.
 	FrameMetadata(fileID libpf.FileID, addressOrLine libpf.AddressOrLineno,
 		lineNumber libpf.SourceLineno, functionOffset uint32, functionName, filePath string)
+
+	// ProcessMetadata accepts metadata associated with a process and caches this information
+	// before a periodic reporting to the backend.
+	ProcessMetadata(ctx context.Context, pid libpf.PID, exe string)
 }
 
 type HostMetadataReporter interface {

--- a/reporter/otlp_reporter.go
+++ b/reporter/otlp_reporter.go
@@ -39,6 +39,7 @@ type traceInfo struct {
 	podName        string
 	containerName  string
 	apmServiceName string
+	pid            libpf.PID
 }
 
 // sample holds dynamic information about traces.
@@ -101,6 +102,9 @@ type OTLPReporter struct {
 
 	// frames maps frame information to its source location.
 	frames *lru.SyncedLRU[libpf.FileID, map[libpf.AddressOrLineno]sourceInfo]
+
+	// execPathes stores the last known execPath for a PID.
+	execPathes *lru.SyncedLRU[libpf.PID, string]
 }
 
 // hashString is a helper function for LRUs that use string as a key.
@@ -136,7 +140,7 @@ func (r *OTLPReporter) ReportFramesForTrace(trace *libpf.Trace) {
 // caches this information.
 // nolint: dupl
 func (r *OTLPReporter) ReportCountForTrace(traceHash libpf.TraceHash, timestamp libpf.UnixTime32,
-	count uint16, comm, podName, containerName string) {
+	count uint16, comm, podName, containerName string, pid libpf.PID) {
 	if v, exists := r.traces.Peek(traceHash); exists {
 		// As traces is filled from two different API endpoints,
 		// some information for the trace might be available already.
@@ -145,6 +149,7 @@ func (r *OTLPReporter) ReportCountForTrace(traceHash libpf.TraceHash, timestamp 
 		v.comm = comm
 		v.podName = podName
 		v.containerName = containerName
+		v.pid = pid
 
 		r.traces.Add(traceHash, v)
 	} else {
@@ -152,6 +157,7 @@ func (r *OTLPReporter) ReportCountForTrace(traceHash libpf.TraceHash, timestamp 
 			comm:          comm,
 			podName:       podName,
 			containerName: containerName,
+			pid:           pid,
 		})
 	}
 
@@ -184,6 +190,10 @@ func (r *OTLPReporter) ExecutableMetadata(_ context.Context,
 		fileName: fileName,
 		buildID:  buildID,
 	})
+}
+
+func (r *OTLPReporter) ProcessMetadata(_ context.Context, pid libpf.PID, execPath string) {
+	r.execPathes.Add(pid, execPath)
 }
 
 // FrameMetadata accepts metadata associated with a frame and caches this information.
@@ -729,6 +739,16 @@ func getTraceLabels(stringMap map[string]uint32, i traceInfo) []*pprofextended.L
 		labels = append(labels, &pprofextended.Label{
 			Key: int64(apmServiceNameIdx),
 			Str: int64(apmServiceNameValueIdx),
+		})
+	}
+
+	if i.pid != 0 {
+		pidIdx := getStringMapIndex(stringMap, "pid")
+		pidValueIdx := getStringMapIndex(stringMap, string(i.pid))
+
+		labels = append(labels, &pprofextended.Label{
+			Key: int64(pidIdx),
+			Str: int64(pidValueIdx),
 		})
 	}
 

--- a/reporter/otlp_reporter.go
+++ b/reporter/otlp_reporter.go
@@ -743,8 +743,8 @@ func getTraceLabels(stringMap map[string]uint32, i traceInfo) []*pprofextended.L
 	}
 
 	if i.pid != 0 {
-		pidIdx := getStringMapIndex(stringMap, "pid")
-		pidValueIdx := getStringMapIndex(stringMap, string(i.pid))
+		pidIdx := getStringMapIndex(stringMap, "process_id")
+		pidValueIdx := getStringMapIndex(stringMap, fmt.Sprintf("%d", i.pid))
 
 		labels = append(labels, &pprofextended.Label{
 			Key: int64(pidIdx),

--- a/tracehandler/tracehandler.go
+++ b/tracehandler/tracehandler.go
@@ -145,7 +145,7 @@ func (m *traceHandler) HandleTrace(bpfTrace *host.Trace) {
 	if traceKnown {
 		m.bpfTraceCacheHit++
 		m.reporter.ReportCountForTrace(postConvHash, timestamp, 1,
-			bpfTrace.Comm, meta.PodName, meta.ContainerName)
+			bpfTrace.Comm, meta.PodName, meta.ContainerName, bpfTrace.PID)
 		return
 	}
 	m.bpfTraceCacheMiss++
@@ -155,7 +155,7 @@ func (m *traceHandler) HandleTrace(bpfTrace *host.Trace) {
 	log.Debugf("Trace hash remap 0x%x -> 0x%x", bpfTrace.Hash, umTrace.Hash)
 	m.bpfTraceCache.Add(bpfTrace.Hash, umTrace.Hash)
 	m.reporter.ReportCountForTrace(umTrace.Hash, timestamp, 1,
-		bpfTrace.Comm, meta.PodName, meta.ContainerName)
+		bpfTrace.Comm, meta.PodName, meta.ContainerName, bpfTrace.PID)
 
 	// Trace already known to collector by UM hash?
 	if _, known := m.umTraceCache.Get(umTrace.Hash); known {

--- a/tracehandler/tracehandler_test.go
+++ b/tracehandler/tracehandler_test.go
@@ -73,7 +73,7 @@ func (m *mockReporter) ReportFramesForTrace(trace *libpf.Trace) {
 }
 
 func (m *mockReporter) ReportCountForTrace(traceHash libpf.TraceHash,
-	_ libpf.UnixTime32, count uint16, _, _, _ string) {
+	_ libpf.UnixTime32, count uint16, _, _, _ string, _ libpf.PID) {
 	m.reportedCounts = append(m.reportedCounts, reportedCount{
 		traceHash: traceHash,
 		count:     count,

--- a/utils/coredump/coredump.go
+++ b/utils/coredump/coredump.go
@@ -105,6 +105,8 @@ func (c *symbolizationCache) FrameMetadata(fileID libpf.FileID,
 
 func (c *symbolizationCache) ReportFallbackSymbol(libpf.FrameID, string) {}
 
+func (c *symbolizationCache) ProcessMetadata(_ context.Context, _ libpf.PID, _ string) {}
+
 func generateErrorMap() (map[libpf.AddressOrLineno]string, error) {
 	file, err := os.Open("../errors-codegen/errors.json")
 	if err != nil {


### PR DESCRIPTION
## Objective / Motivation

Add a root frame with the path of the executable when the information is available.

## How this is done

This is done in three steps. 

First, we need to provide the reporter with the PID <-> Executable path name mapping. This is done by:
* Adding a `GetExecutablePath()` on the process object, that either returns the main executable for a core dump, or reads `/proc/pid/exe` for live processes)
* On `SynchronizeProcess`, the process manager will call `ProcessMetadata` indicating which pid has which exec name.
* On the reporter we add an LRU that contains the PID <-> Executable mapping, that is updated by `ProcessMetadata` calls.

Then we need to have the PID for the sample we're currently producing. This is done by:
* Updating the tracehandler so that it includes the PID in `ReportCountForTrace`
* Updating `ReportCountForTrace` so that it includes the PID of the frame, this PID will be added to the `traceInfo` structure.

Now we have the PID for each trace, and the PID <-> executable path mapping 🎉 🌮  We use this when producing the pprof in the datadog reporter:
* If the latest frame is a kernel frame, we add a dummy location / function named "kernel"
* Else, we try to find the exec path associated with the PID. If we do, we add a dummy location / function with the name of the executable path. Else we do nothing.

This is an [example profile link](https://app.datadoghq.com/profiling/explorer?query=service%3Anayef-test&agg_m=count&agg_m_source=base&agg_t=count&cols=timestamp%2Cservice%2C%40metrics.core_cpu_cores%2C%40metrics.core_alloc_bytes_per_sec%2Cversion%2Chost&event=AgAAAZAL0Nm4JDhrhAAAAAAAAAAYAAAAAEFaQUwwTnlrQUFBZ2p0TjZyRE4xeWdBQQAAACQAAAAAMDE5MDBiZDEtM2U2MS00YjZlLWE3MTEtOWE0YmJlMzYyMDk1&fromUser=true&profileId=AZAL0NykAAAgjtN6rDN1ygAA&refresh_mode=sliding&stream_sort=timestamp%2Cdesc&viz=stream&from_ts=1718184136798&to_ts=1718185036798&live=true) that showcases this working locally.

![image](https://github.com/DataDog/otel-profiling-agent/assets/11560964/67748c74-d2a0-4b41-9564-c8655ce05e6e)

(Note that the java program present in that image is indeed launched via `ld` hence why we see `ld` there)