### PR TITLE
chore: add a docker-compose file for local development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ otel-profiling-agent
 tracer.ebpf
 tracer.ebpf.arm64
 tracer.ebpf.x86
+.env

--- a/README.md
+++ b/README.md
@@ -33,6 +33,29 @@ sudo otel-profiling-agent -tags 'service:myservice;remote_symbols:yes' -collecti
 
 For this to work you need to run a Datadog agent that listens for APM traffic at `localhost:8126`. If your agent is reachable under a different address, you can modify the `-collection-agent` parameter accordingly.
 
+## Development
+
+A `docker-compose.yml` file is provided to help run the agent in a container for local development.
+
+First, create a `.env` file with the following content:
+
+```
+ARCH=amd64 # required
+DD_API_KEY=your-api-key # required
+DD_SITE=datadoghq.com # optional, defaults to "datadoghq.com"
+OTEL_PROFILING_AGENT_SERVICE=my-service # optional, defaults to "otel-profiling-agent-dev"
+OTEL_PROFILING_AGENT_REPORTER_INTERVAL=10s # optional, defaults to 60s
+```
+
+Then, you can run the agent with the following command:
+
+```
+docker-compose up
+```
+
+The agent will submit profiling data to the Datadog Agent using the value of OTEL_PROFILING_AGENT_SERVICE as the service name.
+
+
 The contents of the original upstream README are below.
 
 ---

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,30 @@
+name: "otel-profiling"
+
+services:
+  agent:
+    build:
+      context: .
+      args:
+        - arch=${ARCH:?error}
+    privileged: true
+    pid: "host"
+    volumes:
+      - .:/agent
+    command: bash -c "sudo mount -t debugfs none /sys/kernel/debug && make && sudo /agent/otel-profiling-agent -tags 'service:${OTEL_PROFILING_AGENT_SERVICE:-otel-profiling-agent-dev};remote_symbols:yes' -collection-agent "http://datadog-agent:8126" -reporter-interval ${OTEL_PROFILING_AGENT_REPORTER_INTERVAL:-60s} -samples-per-second 20 -save-cpuprofile"
+
+  datadog-agent:
+    image: gcr.io/datadoghq/agent:7
+    cgroup: host
+    environment:
+      DD_SITE: ${DD_SITE:-datadoghq.com}
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - /proc/:/host/proc/:ro
+      - /sys/fs/cgroup/:/host/sys/fs/cgroup:ro
+    secrets:
+      - dd-api-key
+    entrypoint: [ '/bin/sh', '-c', 'export DD_API_KEY=$$(cat /run/secrets/dd-api-key) ; /bin/entrypoint.sh' ]
+
+secrets:
+  dd-api-key:
+    environment: DD_API_KEY


### PR DESCRIPTION
add a docker-compose file with the locally built and compiled agent as well as the datadog-agent communicating with each other to make local development more seamless

