### PR TITLE
datadog-reporter: add container name pprof tag (PROF-9951)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
     pid: "host"
     volumes:
       - .:/agent
+      - /var/run/docker.sock:/var/run/docker.sock:ro
     command: bash -c "sudo mount -t debugfs none /sys/kernel/debug && make && sudo /agent/otel-profiling-agent -tags 'service:${OTEL_PROFILING_AGENT_SERVICE:-otel-profiling-agent-dev};remote_symbols:yes' -collection-agent "http://datadog-agent:8126" -reporter-interval ${OTEL_PROFILING_AGENT_REPORTER_INTERVAL:-60s} -samples-per-second 20 -save-cpuprofile"
 
   datadog-agent:

--- a/reporter/datadog_reporter.go
+++ b/reporter/datadog_reporter.go
@@ -341,6 +341,11 @@ func (r *DatadogReporter) reportProfile(ctx context.Context) error {
 	}
 
 	tags := strings.Split(config.ValidatedTags(), ";")
+
+	customAttributes := []string{"container_name"}
+	for _, attr := range customAttributes {
+		tags = append(tags, fmt.Sprintf("ddprof.custom_ctx:%s", attr))
+	}
 	tags = append(tags, "runtime:native", fmt.Sprintf("cpu_arch:%s", runtime.GOARCH))
 	foundService := false
 	// check if service tag is set, if not set it to otel-profiling-agent
@@ -597,7 +602,7 @@ func addTraceLabels(labels map[string][]string, i traceInfo) {
 	}
 
 	if i.containerName != "" {
-		labels["containerName"] = append(labels["containerName"], i.containerName)
+		labels["container_name"] = append(labels["container_name"], i.containerName)
 	}
 
 	if i.apmServiceName != "" {


### PR DESCRIPTION
permits slicing down the profile by container name, by ensuring we add both a pprof label and tag for container name.

we use container_name instead of containerName as we're currently normalizing the tag to containername, and this leads to a discrepancy between the tag and the pprof label (containerName).

also mount docker.sock locally so that the otel-agent is able to find the container names

