### PR TITLE
container metadata: add container_id as a label (PROF-9951)

### DIFF
--- a/containermetadata/containermetadata_test.go
+++ b/containermetadata/containermetadata_test.go
@@ -303,9 +303,9 @@ func TestGetKubernetesPodMetadata(t *testing.T) {
 				if !ok {
 					t.Fatal("container metadata should be in the container metadata cache")
 				}
-				if value.containerID != test.expContainerID {
+				if value.ContainerID != test.expContainerID {
 					t.Fatalf("expected container name %v but got %v",
-						test.expContainerID, value.containerID)
+						test.expContainerID, value.ContainerID)
 				}
 				if value.ContainerName != test.expContainerName {
 					t.Fatalf("expected container name %v but got %v",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
     pid: "host"
     volumes:
       - .:/agent
+      - /var/run/docker.sock:/var/run/docker.sock:ro
     command: bash -c "sudo mount -t debugfs none /sys/kernel/debug && make && sudo /agent/otel-profiling-agent -tags 'service:${OTEL_PROFILING_AGENT_SERVICE:-otel-profiling-agent-dev};remote_symbols:yes' -collection-agent "http://datadog-agent:8126" -reporter-interval ${OTEL_PROFILING_AGENT_REPORTER_INTERVAL:-60s} -samples-per-second 20 -save-cpuprofile"
 
   datadog-agent:

--- a/libpf/libpf.go
+++ b/libpf/libpf.go
@@ -475,6 +475,7 @@ type TraceAndCounts struct {
 	Count         uint16
 	Comm          string
 	PodName       string
+	ContainerID   string
 	ContainerName string
 	PID           PID
 }

--- a/reporter/datadog_reporter.go
+++ b/reporter/datadog_reporter.go
@@ -100,7 +100,7 @@ func (r *DatadogReporter) ReportFramesForTrace(trace *libpf.Trace) {
 // caches this information.
 // nolint: dupl
 func (r *DatadogReporter) ReportCountForTrace(traceHash libpf.TraceHash, timestamp libpf.UnixTime32,
-	count uint16, comm, podName, containerName string, pid libpf.PID) {
+	count uint16, comm, podName, containerID, containerName string, pid libpf.PID) {
 	if v, exists := r.traces.Peek(traceHash); exists {
 		// As traces is filled from two different API endpoints,
 		// some information for the trace might be available already.
@@ -108,6 +108,7 @@ func (r *DatadogReporter) ReportCountForTrace(traceHash libpf.TraceHash, timesta
 		// the existing one.
 		v.comm = comm
 		v.podName = podName
+		v.containerID = containerID
 		v.containerName = containerName
 		v.pid = pid
 
@@ -116,6 +117,7 @@ func (r *DatadogReporter) ReportCountForTrace(traceHash libpf.TraceHash, timesta
 		r.traces.Add(traceHash, traceInfo{
 			comm:          comm,
 			podName:       podName,
+			containerID:   containerID,
 			containerName: containerName,
 			pid:           pid,
 		})
@@ -342,7 +344,7 @@ func (r *DatadogReporter) reportProfile(ctx context.Context) error {
 
 	tags := strings.Split(config.ValidatedTags(), ";")
 
-	customAttributes := []string{"container_name"}
+	customAttributes := []string{"container_id", "container_name"}
 	for _, attr := range customAttributes {
 		tags = append(tags, fmt.Sprintf("ddprof.custom_ctx:%s", attr))
 	}
@@ -599,6 +601,10 @@ func addTraceLabels(labels map[string][]string, i traceInfo) {
 
 	if i.podName != "" {
 		labels["podName"] = append(labels["podName"], i.podName)
+	}
+
+	if i.containerID != "" {
+		labels["container_id"] = append(labels["container_id"], i.containerID)
 	}
 
 	if i.containerName != "" {

--- a/reporter/datadog_reporter.go
+++ b/reporter/datadog_reporter.go
@@ -341,6 +341,11 @@ func (r *DatadogReporter) reportProfile(ctx context.Context) error {
 	}
 
 	tags := strings.Split(config.ValidatedTags(), ";")
+
+	customAttributes := []string{"container_name"}
+	for _, attr := range customAttributes {
+		tags = append(tags, fmt.Sprintf("ddprof.custom_ctx:%s", attr))
+	}
 	tags = append(tags, "runtime:native", fmt.Sprintf("cpu_arch:%s", runtime.GOARCH))
 	foundService := false
 	// check if service tag is set, if not set it to otel-profiling-agent
@@ -597,7 +602,7 @@ func addTraceLabels(labels map[string][]string, i traceInfo) {
 	}
 
 	if i.containerName != "" {
-		labels["containerName"] = append(labels["containerName"], i.containerName)
+		labels["container_name"] = append(labels["container_name"], i.containerName)
 	}
 
 	if i.apmServiceName != "" {

--- a/reporter/iface.go
+++ b/reporter/iface.go
@@ -48,7 +48,7 @@ type TraceReporter interface {
 	// ReportCountForTrace accepts a hash of a trace with a corresponding count and
 	// caches this information before a periodic reporting to the backend.
 	ReportCountForTrace(traceHash libpf.TraceHash, timestamp libpf.UnixTime32,
-		count uint16, comm, podName, containerName string, pid libpf.PID)
+		count uint16, comm, podName, containerID, containerName string, pid libpf.PID)
 }
 
 type SymbolReporter interface {

--- a/reporter/reporter.go
+++ b/reporter/reporter.go
@@ -154,13 +154,14 @@ func (r *GRPCReporter) FrameMetadata(fileID libpf.FileID,
 
 // ReportCountForTrace implements the TraceReporter interface.
 func (r *GRPCReporter) ReportCountForTrace(traceHash libpf.TraceHash, timestamp libpf.UnixTime32,
-	count uint16, comm, podName, containerName string, pid libpf.PID) {
+	count uint16, comm, podName, containerID, containerName string, pid libpf.PID) {
 	r.countsForTracesQueue.append(&libpf.TraceAndCounts{
 		Hash:          traceHash,
 		Timestamp:     timestamp,
 		Count:         count,
 		Comm:          comm,
 		PodName:       podName,
+		ContainerID:   containerID,
 		ContainerName: containerName,
 		PID:           pid,
 	})

--- a/tracehandler/tracehandler.go
+++ b/tracehandler/tracehandler.go
@@ -145,7 +145,7 @@ func (m *traceHandler) HandleTrace(bpfTrace *host.Trace) {
 	if traceKnown {
 		m.bpfTraceCacheHit++
 		m.reporter.ReportCountForTrace(postConvHash, timestamp, 1,
-			bpfTrace.Comm, meta.PodName, meta.ContainerName, bpfTrace.PID)
+			bpfTrace.Comm, meta.PodName, meta.ContainerID, meta.ContainerName, bpfTrace.PID)
 		return
 	}
 	m.bpfTraceCacheMiss++
@@ -155,7 +155,7 @@ func (m *traceHandler) HandleTrace(bpfTrace *host.Trace) {
 	log.Debugf("Trace hash remap 0x%x -> 0x%x", bpfTrace.Hash, umTrace.Hash)
 	m.bpfTraceCache.Add(bpfTrace.Hash, umTrace.Hash)
 	m.reporter.ReportCountForTrace(umTrace.Hash, timestamp, 1,
-		bpfTrace.Comm, meta.PodName, meta.ContainerName, bpfTrace.PID)
+		bpfTrace.Comm, meta.PodName, meta.ContainerID, meta.ContainerName, bpfTrace.PID)
 
 	// Trace already known to collector by UM hash?
 	if _, known := m.umTraceCache.Get(umTrace.Hash); known {

--- a/tracehandler/tracehandler_test.go
+++ b/tracehandler/tracehandler_test.go
@@ -73,7 +73,7 @@ func (m *mockReporter) ReportFramesForTrace(trace *libpf.Trace) {
 }
 
 func (m *mockReporter) ReportCountForTrace(traceHash libpf.TraceHash,
-	_ libpf.UnixTime32, count uint16, _, _, _ string, _ libpf.PID) {
+	_ libpf.UnixTime32, count uint16, _, _, _, _ string, _ libpf.PID) {
 	m.reportedCounts = append(m.reportedCounts, reportedCount{
 		traceHash: traceHash,
 		count:     count,


### PR DESCRIPTION
Add a default parsing pattern for the cgroup file based on https://github.com/open-telemetry/opentelemetry-go/blob/6a0fa3c911a061198302cd1972c2e1a9e5ffa87f/sdk/resource/container.go#L21 to be able to parse the container ID even when the container metadata environment is not detected.

Export containerID attribute to be able to inject it in the `traceInfo` and also hook this up as a pprof label, and a tag for the dd reporter.

Local profile with working docker metadata and both `container_id` and `container_name` tags:
<img width="1059" alt="image" src="https://github.com/DataDog/otel-profiling-agent/assets/11560964/db61db5b-50cf-42a8-b6d8-11e153ffe42a">

Local profile with docker metadata off, and only `container_id` tag:
<img width="1059" alt="image" src="https://github.com/DataDog/otel-profiling-agent/assets/11560964/4a757f56-6674-47d3-acba-f3860ae8dba1">
