### PR TITLE
datadog-reporter: fix panic when frameTypes is empty

### DIFF
--- a/reporter/datadog_reporter.go
+++ b/reporter/datadog_reporter.go
@@ -537,7 +537,8 @@ func (r *DatadogReporter) getPprofProfile() (profile *pprofile.Profile,
 		execPath, _ := r.execPathes.Get(trace.pid)
 
 		// Check if the last frame is a kernel frame.
-		if len(trace.frameTypes) > 0 && trace.frameTypes[len(trace.frameTypes)-1] == libpf.KernelFrame {
+		if len(trace.frameTypes) > 0 &&
+			trace.frameTypes[len(trace.frameTypes)-1] == libpf.KernelFrame {
 			// If the last frame is a kernel frame, we need to add a dummy
 			// location with the kernel as the function name.
 			execPath = "kernel"

--- a/reporter/datadog_reporter.go
+++ b/reporter/datadog_reporter.go
@@ -537,7 +537,7 @@ func (r *DatadogReporter) getPprofProfile() (profile *pprofile.Profile,
 		execPath, _ := r.execPathes.Get(trace.pid)
 
 		// Check if the last frame is a kernel frame.
-		if trace.frameTypes[len(trace.frameTypes)-1] == libpf.KernelFrame {
+		if len(trace.frameTypes) > 0 && trace.frameTypes[len(trace.frameTypes)-1] == libpf.KernelFrame {
 			// If the last frame is a kernel frame, we need to add a dummy
 			// location with the kernel as the function name.
 			execPath = "kernel"


### PR DESCRIPTION
```
goroutine 378 [running]:
github.com/elastic/otel-profiling-agent/reporter.(*DatadogReporter).getPprofProfile(0xc000852000)
	/home/runner/work/otel-profiling-agent/otel-profiling-agent/reporter/datadog_reporter.go:540 +0x27cd
github.com/elastic/otel-profiling-agent/reporter.(*DatadogReporter).reportProfile(0xc000852000, {0x2ff80d0, 0xc0006900a0})
	/home/runner/work/otel-profiling-agent/otel-profiling-agent/reporter/datadog_reporter.go:318 +0x55
github.com/elastic/otel-profiling-agent/reporter.StartDatadog.func1()
	/home/runner/work/otel-profiling-agent/otel-profiling-agent/reporter/datadog_reporter.go:297 +0x15d
created by github.com/elastic/otel-profiling-agent/reporter.StartDatadog in goroutine 1
	/home/runner/work/otel-profiling-agent/otel-profiling-agent/reporter/datadog_reporter.go:287 +0x548
```

It's noteworthy that an empty trace can be emitted. Looking at the code, it could come from all frames having the error bit set per https://github.com/DataDog/otel-profiling-agent/blob/0945fe628da5c4854d55dd95e5dc4b4cf46a3c76/processmanager/manager.go#L220-L225 as by default error frames are filtered out https://github.com/DataDog/otel-profiling-agent/blob/0945fe628da5c4854d55dd95e5dc4b4cf46a3c76/cli_flags_internal.go#L53-L54