### PR TITLE
reporter: attach thread ID to emitted profiles (PROF-9959)

### DIFF
--- a/host/host.go
+++ b/host/host.go
@@ -63,4 +63,5 @@ type Trace struct {
 	Hash   TraceHash
 	KTime  libpf.KTime
 	PID    libpf.PID
+	TID    libpf.TID
 }

--- a/libpf/libpf.go
+++ b/libpf/libpf.go
@@ -54,6 +54,9 @@ func (p PID) Hash32() uint32 {
 	return uint32(p)
 }
 
+// TID represent a thread ID
+type TID int32
+
 // FileID is used for unique identifiers for files
 type FileID struct {
 	basehash.Hash128
@@ -478,6 +481,7 @@ type TraceAndCounts struct {
 	ContainerID   string
 	ContainerName string
 	PID           PID
+	TID           TID
 }
 
 type FrameMetadata struct {

--- a/reporter/datadog_reporter.go
+++ b/reporter/datadog_reporter.go
@@ -100,7 +100,7 @@ func (r *DatadogReporter) ReportFramesForTrace(trace *libpf.Trace) {
 // caches this information.
 // nolint: dupl
 func (r *DatadogReporter) ReportCountForTrace(traceHash libpf.TraceHash, timestamp libpf.UnixTime32,
-	count uint16, comm, podName, containerID, containerName string, pid libpf.PID) {
+	count uint16, comm, podName, containerID, containerName string, pid libpf.PID, tid libpf.TID) {
 	if v, exists := r.traces.Peek(traceHash); exists {
 		// As traces is filled from two different API endpoints,
 		// some information for the trace might be available already.
@@ -111,6 +111,7 @@ func (r *DatadogReporter) ReportCountForTrace(traceHash libpf.TraceHash, timesta
 		v.containerID = containerID
 		v.containerName = containerName
 		v.pid = pid
+		v.tid = tid
 
 		r.traces.Add(traceHash, v)
 	} else {
@@ -120,6 +121,7 @@ func (r *DatadogReporter) ReportCountForTrace(traceHash libpf.TraceHash, timesta
 			containerID:   containerID,
 			containerName: containerName,
 			pid:           pid,
+			tid:           tid,
 		})
 	}
 
@@ -618,6 +620,13 @@ func addTraceLabels(labels map[string][]string, i traceInfo) {
 
 	if i.pid != 0 {
 		labels["process_id"] = append(labels["process_id"], fmt.Sprintf("%d", i.pid))
+	}
+
+	if i.tid != 0 {
+		// The naming has an impact on the backend side,
+		// this is why we use "thread id" instead of "thread_id"
+		// This is also consistent with ddprof.
+		labels["thread id"] = append(labels["thread id"], fmt.Sprintf("%d", i.tid))
 	}
 }
 

--- a/reporter/iface.go
+++ b/reporter/iface.go
@@ -48,7 +48,8 @@ type TraceReporter interface {
 	// ReportCountForTrace accepts a hash of a trace with a corresponding count and
 	// caches this information before a periodic reporting to the backend.
 	ReportCountForTrace(traceHash libpf.TraceHash, timestamp libpf.UnixTime32,
-		count uint16, comm, podName, containerID, containerName string, pid libpf.PID)
+		count uint16, comm, podName, containerID, containerName string,
+		pid libpf.PID, tid libpf.TID)
 }
 
 type SymbolReporter interface {

--- a/reporter/reporter.go
+++ b/reporter/reporter.go
@@ -154,7 +154,7 @@ func (r *GRPCReporter) FrameMetadata(fileID libpf.FileID,
 
 // ReportCountForTrace implements the TraceReporter interface.
 func (r *GRPCReporter) ReportCountForTrace(traceHash libpf.TraceHash, timestamp libpf.UnixTime32,
-	count uint16, comm, podName, containerID, containerName string, pid libpf.PID) {
+	count uint16, comm, podName, containerID, containerName string, pid libpf.PID, tid libpf.TID) {
 	r.countsForTracesQueue.append(&libpf.TraceAndCounts{
 		Hash:          traceHash,
 		Timestamp:     timestamp,
@@ -164,6 +164,7 @@ func (r *GRPCReporter) ReportCountForTrace(traceHash libpf.TraceHash, timestamp 
 		ContainerID:   containerID,
 		ContainerName: containerName,
 		PID:           pid,
+		TID:           tid,
 	})
 }
 

--- a/support/ebpf/native_stack_trace.ebpf.c
+++ b/support/ebpf/native_stack_trace.ebpf.c
@@ -800,6 +800,7 @@ static inline
 int collect_trace(struct pt_regs *ctx) {
   // Get the PID and TGID register.
   u64 id = bpf_get_current_pid_tgid();
+  u64 tid = id & 0xFFFFFFFF;
   u64 pid = id >> 32;
 
   if (pid == 0) {
@@ -817,6 +818,7 @@ int collect_trace(struct pt_regs *ctx) {
   }
 
   Trace *trace = &record->trace;
+  trace->tid = tid;
   trace->pid = pid;
   trace->ktime = bpf_ktime_get_ns();
   if (bpf_get_current_comm(&(trace->comm), sizeof(trace->comm)) < 0) {

--- a/support/ebpf/types.h
+++ b/support/ebpf/types.h
@@ -450,6 +450,8 @@ typedef struct V8ProcInfo {
 typedef struct Trace {
   // The process ID
   u32 pid;
+  // The thread ID
+  u32 tid;
   // Monotonic kernel time in nanosecond precision.
   u64 ktime;
   // The current COMM of the thread of this Trace.

--- a/tracehandler/tracehandler.go
+++ b/tracehandler/tracehandler.go
@@ -145,7 +145,8 @@ func (m *traceHandler) HandleTrace(bpfTrace *host.Trace) {
 	if traceKnown {
 		m.bpfTraceCacheHit++
 		m.reporter.ReportCountForTrace(postConvHash, timestamp, 1,
-			bpfTrace.Comm, meta.PodName, meta.ContainerID, meta.ContainerName, bpfTrace.PID)
+			bpfTrace.Comm, meta.PodName, meta.ContainerID, meta.ContainerName,
+			bpfTrace.PID, bpfTrace.TID)
 		return
 	}
 	m.bpfTraceCacheMiss++
@@ -155,7 +156,8 @@ func (m *traceHandler) HandleTrace(bpfTrace *host.Trace) {
 	log.Debugf("Trace hash remap 0x%x -> 0x%x", bpfTrace.Hash, umTrace.Hash)
 	m.bpfTraceCache.Add(bpfTrace.Hash, umTrace.Hash)
 	m.reporter.ReportCountForTrace(umTrace.Hash, timestamp, 1,
-		bpfTrace.Comm, meta.PodName, meta.ContainerID, meta.ContainerName, bpfTrace.PID)
+		bpfTrace.Comm, meta.PodName, meta.ContainerID, meta.ContainerName,
+		bpfTrace.PID, bpfTrace.TID)
 
 	// Trace already known to collector by UM hash?
 	if _, known := m.umTraceCache.Get(umTrace.Hash); known {

--- a/tracehandler/tracehandler_test.go
+++ b/tracehandler/tracehandler_test.go
@@ -73,7 +73,7 @@ func (m *mockReporter) ReportFramesForTrace(trace *libpf.Trace) {
 }
 
 func (m *mockReporter) ReportCountForTrace(traceHash libpf.TraceHash,
-	_ libpf.UnixTime32, count uint16, _, _, _, _ string, _ libpf.PID) {
+	_ libpf.UnixTime32, count uint16, _, _, _, _ string, _ libpf.PID, _ libpf.TID) {
 	m.reportedCounts = append(m.reportedCounts, reportedCount{
 		traceHash: traceHash,
 		count:     count,

--- a/tracer/tracer.go
+++ b/tracer/tracer.go
@@ -840,13 +840,14 @@ func (t *Tracer) loadBpfTrace(raw []byte) *host.Trace {
 	trace := &host.Trace{
 		Comm:  C.GoString((*C.char)(unsafe.Pointer(&ptr.comm))),
 		PID:   libpf.PID(ptr.pid),
+		TID:   libpf.TID(ptr.tid),
 		KTime: libpf.KTime(ptr.ktime),
 	}
 
 	// Trace fields included in the hash:
 	//  - PID, kernel stack ID, length & frame array.
 	// Intentionally excluded:
-	//  - ktime, COMM
+	//  - ktime, COMM, TID
 	ptr.comm = [16]C.char{}
 	ptr.ktime = 0
 	trace.Hash = host.TraceHash(xxh3.Hash128(raw).Lo)


### PR DESCRIPTION
get thread ID from `bpf_get_current_pid_tgid` (based on https://man7.org/linux/man-pages/man7/bpf-helpers.7.html)

and pass it down through the trace to the reporter. attach it to the emitted pprof as a label

Process-agent profile filtered on a thread ID:
![image](https://github.com/DataDog/otel-profiling-agent/assets/11560964/7f7208cf-c4e6-4036-a172-01e85106ece9)

Process-agent profile filtered on a process ID (for the same thread ID):
![image](https://github.com/DataDog/otel-profiling-agent/assets/11560964/3904721d-f651-4441-a71d-2446f75f806b)


