### PR TITLE
[PROF-9960] Use mapping filename instead of comm for function filename

### DIFF
--- a/reporter/datadog_reporter.go
+++ b/reporter/datadog_reporter.go
@@ -344,7 +344,7 @@ func (r *DatadogReporter) reportProfile(ctx context.Context) error {
 
 	tags := strings.Split(config.ValidatedTags(), ";")
 
-	customAttributes := []string{"container_id", "container_name"}
+	customAttributes := []string{"container_id", "container_name", "thread_name"}
 	for _, attr := range customAttributes {
 		tags = append(tags, fmt.Sprintf("ddprof.custom_ctx:%s", attr))
 	}
@@ -597,7 +597,7 @@ func createPprofFunctionEntry(funcMap map[funcInfo]*pprofile.Function,
 
 func addTraceLabels(labels map[string][]string, i traceInfo) {
 	if i.comm != "" {
-		labels["comm"] = append(labels["comm"], i.comm)
+		labels["thread_name"] = append(labels["thread_name"], i.comm)
 	}
 
 	if i.podName != "" {

--- a/reporter/datadog_reporter.go
+++ b/reporter/datadog_reporter.go
@@ -470,7 +470,7 @@ func (r *DatadogReporter) getPprofProfile() (profile *pprofile.Profile,
 					loc.Mapping = tmpMapping
 				}
 				line := pprofile.Line{Function: createPprofFunctionEntry(funcMap, profile, "",
-					trace.comm)}
+					loc.Mapping.File)}
 				loc.Line = append(loc.Line, line)
 			case libpf.KernelFrame:
 				// Reconstruct frameID


### PR DESCRIPTION
Also rename `comm` label into `thread_name` and add it to custom context. 
Usual label name in other profilers is `thread name` but custom context labels cannot have whitespaces...