### PR TITLE
[PROF-9983] Leverage local symbols for otel-profiling-agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,18 @@ sudo otel-profiling-agent -tags 'service:myservice;remote_symbols:yes' -collecti
 
 For this to work you need to run a Datadog agent that listens for APM traffic at `localhost:8126`. If your agent is reachable under a different address, you can modify the `-collection-agent` parameter accordingly.
 
+## Configuration
+
+### Local symbol upload (Experimental)
+
+For compiled languages (C/C++/Rust/Go), the profiling-agent can upload local symbols (when available) to Datadog for symbolication. Symbols need to be available locally (unstripped binairies).
+
+To enable local symbol upload:
+1. Set the `DD_EXPERIMENTAL_LOCAL_SYMBOL_UPLOAD` environment variable to `true`.
+2. Provide a Datadog API key through the `DD_API_KEY` environment variable.
+3. Set the `DD_SITE` environment variable to [your Datadog site](https://docs.datadoghq.com/getting_started/site/#access-the-datadog-site) (e.g. `datadoghq.com`).
+
+
 ## Development
 
 A `docker-compose.yml` file is provided to help run the agent in a container for local development.

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ For this to work you need to run a Datadog agent that listens for APM traffic at
 
 ### Local symbol upload (Experimental)
 
-For compiled languages (C/C++/Rust/Go), the profiling-agent can upload local symbols (when available) to Datadog for symbolication. Symbols need to be available locally (unstripped binairies).
+For compiled languages (C/C++/Rust/Go), the profiling-agent can upload local symbols (when available) to Datadog for symbolication. Symbols need to be available locally (unstripped binaries).
 
 To enable local symbol upload:
 1. Set the `DD_EXPERIMENTAL_LOCAL_SYMBOL_UPLOAD` environment variable to `true`.

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ DD_API_KEY=your-api-key # required
 DD_SITE=datadoghq.com # optional, defaults to "datadoghq.com"
 OTEL_PROFILING_AGENT_SERVICE=my-service # optional, defaults to "otel-profiling-agent-dev"
 OTEL_PROFILING_AGENT_REPORTER_INTERVAL=10s # optional, defaults to 60s
+DD_EXPERIMENTAL_LOCAL_SYMBOL_UPLOAD=true # optional, defaults to false
 ```
 
 Then, you can run the agent with the following command:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,10 +8,15 @@ services:
         - arch=${ARCH:?error}
     privileged: true
     pid: "host"
+    environment:
+      DD_SITE: ${DD_SITE:-datadoghq.com}
+      DD_EXPERIMENTAL_LOCAL_SYMBOL_UPLOAD: ${DD_EXPERIMENTAL_LOCAL_SYMBOL_UPLOAD:-false}
     volumes:
       - .:/agent
       - /var/run/docker.sock:/var/run/docker.sock:ro
-    command: bash -c "sudo mount -t debugfs none /sys/kernel/debug && make && sudo /agent/otel-profiling-agent -tags 'service:${OTEL_PROFILING_AGENT_SERVICE:-otel-profiling-agent-dev};remote_symbols:yes' -collection-agent "http://datadog-agent:8126" -reporter-interval ${OTEL_PROFILING_AGENT_REPORTER_INTERVAL:-60s} -samples-per-second 20 -save-cpuprofile"
+    secrets:
+      - dd-api-key
+    command: ['/bin/sh', '-c', 'export DD_API_KEY=$$(cat /run/secrets/dd-api-key); sudo mount -t debugfs none /sys/kernel/debug && make && sudo -E /agent/otel-profiling-agent -tags "service:${OTEL_PROFILING_AGENT_SERVICE:-otel-profiling-agent-dev};remote_symbols:yes" -collection-agent "http://datadog-agent:8126" -reporter-interval ${OTEL_PROFILING_AGENT_REPORTER_INTERVAL:-60s} -samples-per-second 20 -save-cpuprofile']
 
   datadog-agent:
     image: gcr.io/datadoghq/agent:7
@@ -24,7 +29,7 @@ services:
       - /sys/fs/cgroup/:/host/sys/fs/cgroup:ro
     secrets:
       - dd-api-key
-    entrypoint: [ '/bin/sh', '-c', 'export DD_API_KEY=$$(cat /run/secrets/dd-api-key) ; /bin/entrypoint.sh' ]
+    entrypoint: ['/bin/sh', '-c', 'export DD_API_KEY=$$(cat /run/secrets/dd-api-key) ; /bin/entrypoint.sh']
 
 secrets:
   dd-api-key:

--- a/libpf/process/coredump.go
+++ b/libpf/process/coredump.go
@@ -564,5 +564,5 @@ func (cf *CoredumpFile) ReadAt(p []byte, addr int64) (int, error) {
 // The returned `pfelf.File` is borrowing the coredump file. Closing it will not close the
 // underlying CoredumpFile.
 func (cf *CoredumpFile) OpenELF() (*pfelf.File, error) {
-	return pfelf.NewFile(cf, cf.Base, cf.parent.hasMusl)
+	return pfelf.NewFile(cf.Name, cf, cf.Base, cf.parent.hasMusl)
 }

--- a/libpf/process/process.go
+++ b/libpf/process/process.go
@@ -230,7 +230,7 @@ func (sp *systemProcess) OpenELF(file string) (*pfelf.File, error) {
 			if err != nil {
 				return nil, fmt.Errorf("failed to extract VDSO: %v", err)
 			}
-			return pfelf.NewFile(vdso, 0, false)
+			return pfelf.NewFile(file, vdso, 0, false)
 		}
 		ef, err := pfelf.Open(sp.GetMappingFile(m))
 		if err == nil {

--- a/main.go
+++ b/main.go
@@ -28,6 +28,7 @@ import (
 	"github.com/elastic/otel-profiling-agent/metrics/agentmetrics"
 	"github.com/elastic/otel-profiling-agent/reporter"
 
+	"github.com/elastic/otel-profiling-agent/symbolication"
 	"github.com/elastic/otel-profiling-agent/tracer"
 
 	log "github.com/sirupsen/logrus"
@@ -333,8 +334,22 @@ func mainWithExitCode() exitCode {
 	// Start reporter metric reporting with 60 second intervals.
 	defer reportermetrics.Start(mainCtx, rep, 60*time.Second)()
 
+	uploader := symbolication.NewNoopUploader()
+
+	ddSymbolUpload := os.Getenv("DD_EXPERIMENTAL_LOCAL_SYMBOL_UPLOAD")
+	if ddSymbolUpload == "true" {
+		log.Infof("Enabling Datadog local symbol upload")
+		uploader, err = symbolication.NewDatadogUploader()
+		if err != nil {
+			log.Errorf(
+				"Failed to create Datadog symbol uploader, symbol upload will be disabled: %v",
+				err,
+			)
+		}
+	}
+
 	// Load the eBPF code and map definitions
-	trc, err := tracer.NewTracer(mainCtx, rep, times, includeTracers, !argSendErrorFrames)
+	trc, err := tracer.NewTracer(mainCtx, rep, uploader, times, includeTracers, !argSendErrorFrames)
 	if err != nil {
 		msg := fmt.Sprintf("Failed to load eBPF tracer: %s", err)
 		log.Error(msg)

--- a/main.go
+++ b/main.go
@@ -345,6 +345,7 @@ func mainWithExitCode() exitCode {
 				"Failed to create Datadog symbol uploader, symbol upload will be disabled: %v",
 				err,
 			)
+			uploader = symbolication.NewNoopUploader()
 		}
 	}
 

--- a/processmanager/manager.go
+++ b/processmanager/manager.go
@@ -28,6 +28,7 @@ import (
 	pmebpf "github.com/elastic/otel-profiling-agent/processmanager/ebpf"
 	eim "github.com/elastic/otel-profiling-agent/processmanager/execinfomanager"
 	"github.com/elastic/otel-profiling-agent/reporter"
+	"github.com/elastic/otel-profiling-agent/symbolication"
 )
 
 const (
@@ -63,7 +64,8 @@ var (
 // the default implementation.
 func New(ctx context.Context, includeTracers []bool, monitorInterval time.Duration,
 	ebpf pmebpf.EbpfHandler, fileIDMapper FileIDMapper, symbolReporter reporter.SymbolReporter,
-	sdp nativeunwind.StackDeltaProvider, filterErrorFrames bool) (*ProcessManager, error) {
+	uploader symbolication.Uploader, sdp nativeunwind.StackDeltaProvider,
+	filterErrorFrames bool) (*ProcessManager, error) {
 	if fileIDMapper == nil {
 		var err error
 		fileIDMapper, err = newFileIDMapper(lruFileIDCacheSize)
@@ -79,7 +81,7 @@ func New(ctx context.Context, includeTracers []bool, monitorInterval time.Durati
 	}
 	elfInfoCache.SetLifetime(elfInfoCacheTTL)
 
-	em := eim.NewExecutableInfoManager(sdp, ebpf, includeTracers)
+	em := eim.NewExecutableInfoManager(sdp, uploader, ebpf, includeTracers)
 
 	interpreters := make(map[libpf.PID]map[libpf.OnDiskFileIdentifier]interpreter.Instance)
 

--- a/processmanager/manager_test.go
+++ b/processmanager/manager_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/elastic/otel-profiling-agent/lpm"
 	"github.com/elastic/otel-profiling-agent/metrics"
 	pmebpf "github.com/elastic/otel-profiling-agent/processmanager/ebpf"
+	"github.com/elastic/otel-profiling-agent/symbolication"
 )
 
 // dummyProcess implements pfelf.Process for testing purposes
@@ -302,6 +303,7 @@ func TestInterpreterConvertTrace(t *testing.T) {
 				nil,
 				nil,
 				nil,
+				nil,
 				true)
 			if err != nil {
 				t.Fatalf("Failed to initialize new process manager: %v", err)
@@ -400,6 +402,7 @@ func TestNewMapping(t *testing.T) {
 				ebpfMockup,
 				NewMapFileIDMapper(),
 				nil,
+				symbolication.NewNoopUploader(),
 				&dummyProvider,
 				true)
 			if err != nil {
@@ -598,6 +601,7 @@ func TestProcExit(t *testing.T) {
 				ebpfMockup,
 				NewMapFileIDMapper(),
 				nil,
+				symbolication.NewNoopUploader(),
 				&dummyProvider,
 				true)
 			if err != nil {

--- a/processmanager/processinfo.go
+++ b/processmanager/processinfo.go
@@ -216,8 +216,15 @@ func (pm *ProcessManager) handleNewInterpreter(pr process.Process, m *Mapping,
 // handleNewMapping processes new file backed mappings
 func (pm *ProcessManager) handleNewMapping(pr process.Process, m *Mapping,
 	elfRef *pfelf.Reference) error {
+	fileID, ok := pm.FileIDMapper.Get(m.FileID)
+	if !ok {
+		log.Debugf("file ID lookup failed for PID %d, file ID %d",
+			pr.PID(), m.FileID)
+		fileID = libpf.UnsymbolizedFileID
+	}
+
 	// Resolve executable info first
-	ei, err := pm.eim.AddOrIncRef(m.FileID, elfRef)
+	ei, err := pm.eim.AddOrIncRef(m.FileID, fileID, elfRef)
 	if err != nil {
 		return err
 	}

--- a/symbolication/datadog_uploader.go
+++ b/symbolication/datadog_uploader.go
@@ -1,0 +1,255 @@
+package symbolication
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"mime/multipart"
+	"net/http"
+	"net/textproto"
+	"net/url"
+	"os"
+	"os/exec"
+	"runtime"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+
+	"github.com/elastic/otel-profiling-agent/libpf"
+	"github.com/elastic/otel-profiling-agent/libpf/pfelf"
+	"github.com/elastic/otel-profiling-agent/libpf/vc"
+)
+
+const sourceMapEndpoint = "/api/v2/srcmap"
+
+type DatadogUploader struct {
+	ddAPIKey  string
+	intakeURL string
+}
+
+var _ Uploader = (*DatadogUploader)(nil)
+
+func NewDatadogUploader() (Uploader, error) {
+	err := exec.Command("objcopy", "--version").Run()
+	if err != nil {
+		return nil, fmt.Errorf("objcopy is not available: %w", err)
+	}
+
+	ddAPIKey := os.Getenv("DD_API_KEY")
+	if ddAPIKey == "" {
+		return nil, fmt.Errorf("DD_API_KEY is not set")
+	}
+
+	ddSite := os.Getenv("DD_SITE")
+	if ddSite == "" {
+		return nil, fmt.Errorf("DD_SITE is not set")
+	}
+
+	intakeURL, err := url.JoinPath("https://sourcemap-intake."+ddSite, sourceMapEndpoint)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse URL: %w", err)
+	}
+
+	return &DatadogUploader{
+		ddAPIKey:  ddAPIKey,
+		intakeURL: intakeURL,
+	}, nil
+}
+
+func (d *DatadogUploader) HandleExecutable(ctx context.Context, elfRef *pfelf.Reference,
+	fileID libpf.FileID) error {
+	fileName := elfRef.FileName()
+	ef, err := elfRef.GetELF()
+	// If the ELF file is not found, we ignore it
+	// This can happen for short-lived processes that are already gone by the time
+	// we try to upload symbols
+	if errors.Is(err, fs.ErrNotExist) {
+		log.Debugf("Skipping executable %s as it does not exist", fileName)
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("could not get ELF: %w", err)
+	}
+
+	// We only upload symbols for executables that have DWARF data
+	if !ef.HasDWARFData() {
+		log.Debugf("Skipping executable %s as it does not have DWARF data", fileName)
+		return nil
+	}
+
+	e, err := newExecutableMetadata(fileName, ef, fileID)
+	if err != nil {
+		return err
+	}
+
+	inputFilePath, err := ef.FilePath()
+	if err != nil {
+		return fmt.Errorf("failed to get ELF file path: %w", err)
+	}
+
+	symbolFile, err := os.CreateTemp("", "objcopy-debug")
+	if err != nil {
+		return fmt.Errorf("failed to create temp file: %w", err)
+	}
+
+	err = d.copySymbols(ctx, inputFilePath, symbolFile.Name())
+	if err != nil {
+		return fmt.Errorf("failed to copy symbols: %w", err)
+	}
+
+	// TODO:
+	// This will launch a goroutine to upload the symbols, per executable
+	// which would potentially lead to a large number of goroutines
+	// if there are many executables.
+	// Ideally, we should limit the number of concurrent uploads
+	go func() {
+		d.uploadSymbols(symbolFile, e)
+		symbolFile.Close()
+		os.Remove(symbolFile.Name())
+	}()
+
+	return nil
+}
+
+type executableMetadata struct {
+	Arch       string `json:"arch"`
+	GNUBuildID string `json:"gnu_build_id"`
+	GoBuildID  string `json:"go_build_id"`
+	FileHash   string `json:"file_hash"`
+	Platform   string `json:"platform"`
+	Type       string `json:"type"`
+
+	fileName string
+}
+
+func newExecutableMetadata(fileName string, elf *pfelf.File,
+	fileID libpf.FileID) (*executableMetadata, error) {
+	buildID, err := elf.GetBuildID()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get build id: %w", err)
+	}
+
+	goBuildID := ""
+	if elf.IsGolang() {
+		goBuildID, err = elf.GetGoBuildID()
+		if err != nil {
+			return nil, fmt.Errorf("failed to get go build id: %w", err)
+		}
+	}
+
+	return &executableMetadata{
+		Arch:       runtime.GOARCH,
+		GNUBuildID: buildID,
+		GoBuildID:  goBuildID,
+		FileHash:   fileID.StringNoQuotes(),
+		Platform:   "elf",
+		Type:       "elf_symbol_file",
+
+		fileName: fileName,
+	}, nil
+}
+
+func (d *DatadogUploader) copySymbols(ctx context.Context, inputPath, outputPath string) error {
+	args := []string{
+		"--only-keep-debug",
+		"--remove-section=.gdb_index",
+		inputPath,
+		outputPath,
+	}
+	err := exec.CommandContext(ctx, "objcopy", args...).Run()
+	if err != nil {
+		return fmt.Errorf("failed to extract debug symbols: %w", err)
+	}
+	return nil
+}
+
+func (d *DatadogUploader) uploadSymbols(symbolFile *os.File, e *executableMetadata) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	req, err := d.buildSymbolUploadRequest(ctx, symbolFile, e)
+	if err != nil {
+		log.Errorf("Failed to build symbol upload request: %v", err)
+		return
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		log.Errorf("Failed to upload symbols: %v", err)
+		return
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		respBody, _ := io.ReadAll(resp.Body)
+
+		log.Errorf("Failed to upload symbols: %s, %s", resp.Status, string(respBody))
+		return
+	}
+
+	log.Infof("Symbols uploaded successfully for executable: %+v", e)
+}
+
+func (d *DatadogUploader) buildSymbolUploadRequest(ctx context.Context, symbolFile *os.File,
+	e *executableMetadata) (*http.Request, error) {
+	b := new(bytes.Buffer)
+
+	gzipped := gzip.NewWriter(b)
+
+	mw := multipart.NewWriter(gzipped)
+
+	// Copy the symbol file into the multipart writer
+	filePart, err := mw.CreateFormFile("elf_symbol_file", "elf_symbol_file")
+	if err != nil {
+		return nil, fmt.Errorf("failed to create form file: %w", err)
+	}
+
+	_, err = io.Copy(filePart, symbolFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to copy symbol file: %w", err)
+	}
+
+	// Write the event metadata into the multipart writer
+	eventPart, err := mw.CreatePart(textproto.MIMEHeader{
+		"Content-Disposition": []string{`form-data; name="event"; filename="event.json"`},
+		"Content-Type":        []string{"application/json"},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create event part: %w", err)
+	}
+
+	err = json.NewEncoder(eventPart).Encode(e)
+	if err != nil {
+		return nil, fmt.Errorf("failed to write JSON metadata: %w", err)
+	}
+
+	// Close the multipart writer then the gzip writer
+	err = mw.Close()
+	if err != nil {
+		return nil, fmt.Errorf("failed to close multipart writer: %w", err)
+	}
+
+	err = gzipped.Close()
+	if err != nil {
+		return nil, fmt.Errorf("failed to close gzip writer: %w", err)
+	}
+
+	r, err := http.NewRequestWithContext(ctx, http.MethodPost, d.intakeURL, b)
+	if err != nil {
+		log.Error("Failed to create request", err)
+		return nil, err
+	}
+
+	r.Header.Set("DD-API-KEY", d.ddAPIKey)
+	r.Header.Set("DD-EVP-ORIGIN", "otel-profiling-agent")
+	r.Header.Set("DD-EVP-ORIGIN-VERSION", vc.Version())
+	r.Header.Set("Content-Type", mw.FormDataContentType())
+	r.Header.Set("Content-Encoding", "gzip")
+	return r, nil
+}

--- a/symbolication/datadog_uploader.go
+++ b/symbolication/datadog_uploader.go
@@ -5,10 +5,8 @@ import (
 	"compress/gzip"
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
-	"io/fs"
 	"mime/multipart"
 	"net/http"
 	"net/textproto"
@@ -68,17 +66,16 @@ func (d *DatadogUploader) HandleExecutable(ctx context.Context, elfRef *pfelf.Re
 	// If the ELF file is not found, we ignore it
 	// This can happen for short-lived processes that are already gone by the time
 	// we try to upload symbols
-	if errors.Is(err, fs.ErrNotExist) {
-		log.Debugf("Skipping executable %s as it does not exist", fileName)
-		return nil
-	}
 	if err != nil {
-		return fmt.Errorf("could not get ELF: %w", err)
+		log.Debugf("Skipping symbol upload for executable %s: %v",
+			fileName, err)
+		return nil
 	}
 
 	// We only upload symbols for executables that have DWARF data
 	if !ef.HasDWARFData() {
-		log.Debugf("Skipping executable %s as it does not have DWARF data", fileName)
+		log.Debugf("Skipping symbol upload for executable %s as it does not have DWARF data",
+			fileName)
 		return nil
 	}
 

--- a/symbolication/iface.go
+++ b/symbolication/iface.go
@@ -1,0 +1,11 @@
+package symbolication
+
+import (
+	"context"
+	"github.com/elastic/otel-profiling-agent/libpf"
+	"github.com/elastic/otel-profiling-agent/libpf/pfelf"
+)
+
+type Uploader interface {
+	HandleExecutable(ctx context.Context, elfRef *pfelf.Reference, fileID libpf.FileID) error
+}

--- a/symbolication/uploader.go
+++ b/symbolication/uploader.go
@@ -1,0 +1,20 @@
+package symbolication
+
+import (
+	"context"
+	"github.com/elastic/otel-profiling-agent/libpf"
+	"github.com/elastic/otel-profiling-agent/libpf/pfelf"
+)
+
+var _ Uploader = (*NoopUploader)(nil)
+
+type NoopUploader struct{}
+
+func (n *NoopUploader) HandleExecutable(_ context.Context, _ *pfelf.Reference,
+	_ libpf.FileID) error {
+	return nil
+}
+
+func NewNoopUploader() Uploader {
+	return &NoopUploader{}
+}

--- a/tracer/tracer.go
+++ b/tracer/tracer.go
@@ -42,6 +42,7 @@ import (
 	pmebpf "github.com/elastic/otel-profiling-agent/processmanager/ebpf"
 	"github.com/elastic/otel-profiling-agent/reporter"
 	"github.com/elastic/otel-profiling-agent/support"
+	"github.com/elastic/otel-profiling-agent/symbolication"
 )
 
 /*
@@ -200,8 +201,8 @@ func collectIntervalCacheMetrics(ctx context.Context, cache nativeunwind.Interva
 
 // NewTracer loads eBPF code and map definitions from the ELF module at the configured
 // path.
-func NewTracer(ctx context.Context, rep reporter.SymbolReporter, intervals Intervals,
-	includeTracers []bool, filterErrorFrames bool) (*Tracer, error) {
+func NewTracer(ctx context.Context, rep reporter.SymbolReporter, uploader symbolication.Uploader,
+	intervals Intervals, includeTracers []bool, filterErrorFrames bool) (*Tracer, error) {
 	kernelSymbols, err := proc.GetKallsyms("/proc/kallsyms")
 	if err != nil {
 		return nil, fmt.Errorf("failed to read kernel symbols: %v", err)
@@ -236,7 +237,7 @@ func NewTracer(ctx context.Context, rep reporter.SymbolReporter, intervals Inter
 	hasBatchOperations := ebpfHandler.SupportsGenericBatchOperations()
 
 	processManager, err := pm.New(ctx, includeTracers, intervals.MonitorInterval(), ebpfHandler,
-		nil, rep, localStackDeltaProvider, filterErrorFrames)
+		nil, rep, uploader, localStackDeltaProvider, filterErrorFrames)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create processManager: %v", err)
 	}

--- a/utils/coredump/coredump.go
+++ b/utils/coredump/coredump.go
@@ -231,7 +231,7 @@ func ExtractTraces(ctx context.Context, pr process.Process, debug bool,
 	}
 
 	manager, err := pm.New(todo, includeTracers, monitorInterval, &coredumpEbpfMaps,
-		pm.NewMapFileIDMapper(), symCache, coredumpOpener, false)
+		pm.NewMapFileIDMapper(), symCache, nil, coredumpOpener, false)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get Interpreter manager: %v", err)
 	}

--- a/utils/coredump/storecoredump.go
+++ b/utils/coredump/storecoredump.go
@@ -54,7 +54,7 @@ func (scd *StoreCoredump) OpenMappingFile(m *process.Mapping) (process.ReadAtClo
 func (scd *StoreCoredump) OpenELF(path string) (*pfelf.File, error) {
 	file, err := scd.openFile(path)
 	if err == nil {
-		return pfelf.NewFile(file, 0, false)
+		return pfelf.NewFile(path, file, 0, false)
 	}
 	if !errors.Is(err, os.ErrNotExist) {
 		return nil, err
@@ -70,7 +70,7 @@ func OpenStoreCoredump(store *modulestore.Store, coreFileRef modulestore.ID, mod
 	if err != nil {
 		return nil, fmt.Errorf("failed to open coredump file reader: %w", err)
 	}
-	coreELF, err := pfelf.NewFile(reader, 0, false)
+	coreELF, err := pfelf.NewFile("", reader, 0, false)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open coredump ELF: %w", err)
 	}


### PR DESCRIPTION
Upload symbols for executables when symbols are available locally.

By default, this is a no-op. When `DD_EXPERIMENTAL_LOCAL_SYMBOL_UPLOAD` environment variable is set to true, this will kick off the symbol upload logic for each new executable found in a mapping.

The datadog uploader requires setting up `DD_API_KEY` and `DD_SITE`. For now, symbols are only uploaded for executables which contain DWARF data.

I tried keeping changes to `otel-profiling-agent` to a minimum, the main changes requires are:
* Wiring up the uploader in `execinfomanager`, and
* Passing the global file ID to `execinfomanager` (in addition to the host-local ID), to be able to pass it to the uploader, and
* Including the ELF file path in `pfelf.File`, as passed to os.Open (so that we're able to get a file path to feed to `objcopy`, that will always work for containers - for e.g. mapping files path) 

A few examples of a profiles remotely symbolicated thanks to the local upload: 
![image](https://github.com/DataDog/otel-profiling-agent/assets/11560964/4462355d-986d-4ee4-a0ae-06c1b16f6c25)
![image](https://github.com/DataDog/otel-profiling-agent/assets/11560964/65e8314a-96ae-4ee5-b115-09873c80f9a5)
