### PR TITLE
[PROF-10045] uploader: fix segfault on failure to init datadog uploader

### DIFF
--- a/main.go
+++ b/main.go
@@ -345,6 +345,7 @@ func mainWithExitCode() exitCode {
 				"Failed to create Datadog symbol uploader, symbol upload will be disabled: %v",
 				err,
 			)
+			uploader = symbolication.NewNoopUploader()
 		}
 	}
 


### PR DESCRIPTION
when we fail to initialize the datadog symbol uploader, we set the uploader to nil, which will cause a panic later on when handling a new executable for symbol upload.

this sets the uploader to `symbolication.NewNoopUploader()` when the datadog uploader is set up, but fails to be initialized.

