### PR TITLE
reporter: always append remote_symbols:yes tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ sudo mount -t debugfs none /sys/kernel/debug
 After that, you can start the agent as shown below:
 
 ```
-sudo otel-profiling-agent -tags 'service:myservice;remote_symbols:yes' -collection-agent "http://localhost:8126" -reporter-interval 60s -samples-per-second 20
+sudo otel-profiling-agent -tags 'service:myservice' -collection-agent "http://localhost:8126" -reporter-interval 60s -samples-per-second 20
 ```
 
 For this to work you need to run a Datadog agent that listens for APM traffic at `localhost:8126`. If your agent is reachable under a different address, you can modify the `-collection-agent` parameter accordingly.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock:ro
     secrets:
       - dd-api-key
-    command: ['/bin/sh', '-c', 'export DD_API_KEY=$$(cat /run/secrets/dd-api-key); sudo mount -t debugfs none /sys/kernel/debug && make && sudo -E /agent/otel-profiling-agent -tags "service:${OTEL_PROFILING_AGENT_SERVICE:-otel-profiling-agent-dev};remote_symbols:yes" -collection-agent "http://datadog-agent:8126" -reporter-interval ${OTEL_PROFILING_AGENT_REPORTER_INTERVAL:-60s} -samples-per-second 20 -save-cpuprofile']
+    command: ['/bin/sh', '-c', 'export DD_API_KEY=$$(cat /run/secrets/dd-api-key); sudo mount -t debugfs none /sys/kernel/debug && make && sudo -E /agent/otel-profiling-agent -tags "service:${OTEL_PROFILING_AGENT_SERVICE:-otel-profiling-agent-dev}" -collection-agent "http://datadog-agent:8126" -reporter-interval ${OTEL_PROFILING_AGENT_REPORTER_INTERVAL:-60s} -samples-per-second 20 -save-cpuprofile']
 
   datadog-agent:
     image: gcr.io/datadoghq/agent:7

--- a/reporter/datadog_reporter.go
+++ b/reporter/datadog_reporter.go
@@ -350,7 +350,9 @@ func (r *DatadogReporter) reportProfile(ctx context.Context) error {
 	for _, attr := range customAttributes {
 		tags = append(tags, fmt.Sprintf("ddprof.custom_ctx:%s", attr))
 	}
-	tags = append(tags, "runtime:native", fmt.Sprintf("cpu_arch:%s", runtime.GOARCH))
+	tags = append(tags, "runtime:native", "remote_symbols:yes",
+		fmt.Sprintf("cpu_arch:%s", runtime.GOARCH),
+	)
 	foundService := false
 	// check if service tag is set, if not set it to otel-profiling-agent
 	for _, tag := range tags {


### PR DESCRIPTION
Always append `remote_symbols:yes` as a tag in the profiler