### PR TITLE
uploader: add support for dry run upload

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
     environment:
       DD_SITE: ${DD_SITE:-datadoghq.com}
       DD_EXPERIMENTAL_LOCAL_SYMBOL_UPLOAD: ${DD_EXPERIMENTAL_LOCAL_SYMBOL_UPLOAD:-false}
+      DD_EXPERIMENTAL_LOCAL_SYMBOL_UPLOAD_DRY_RUN: ${DD_EXPERIMENTAL_LOCAL_SYMBOL_UPLOAD_DRY_RUN:-false}
       VERSION: ${VERSION:-local-dev}
     volumes:
       - .:/agent

--- a/processmanager/execinfomanager/manager.go
+++ b/processmanager/execinfomanager/manager.go
@@ -7,16 +7,14 @@
 package execinfomanager
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"os"
 	"time"
 
+	lru "github.com/elastic/go-freelru"
 	"github.com/elastic/otel-profiling-agent/libpf"
 	log "github.com/sirupsen/logrus"
-
-	lru "github.com/elastic/go-freelru"
 
 	"github.com/elastic/otel-profiling-agent/config"
 	"github.com/elastic/otel-profiling-agent/host"
@@ -234,14 +232,7 @@ func (mgr *ExecutableInfoManager) AddOrIncRef(hostFileID host.FileID, fileID lib
 
 	// Processing symbols for upload can take a while, so we release the lock
 	// before doing this.
-	// We also use a timeout to avoid blocking the process manager for too long.
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
-
-	err = mgr.uploader.HandleExecutable(ctx, elfRef, fileID)
-	if err != nil {
-		log.Errorf("Failed to handle executable %v: %v", elfRef.FileName(), err)
-	}
+	mgr.uploader.HandleExecutable(elfRef, fileID)
 
 	return info.ExecutableInfo, nil
 }

--- a/symbolication/iface.go
+++ b/symbolication/iface.go
@@ -1,12 +1,10 @@
 package symbolication
 
 import (
-	"context"
-
 	"github.com/elastic/otel-profiling-agent/libpf"
 	"github.com/elastic/otel-profiling-agent/libpf/pfelf"
 )
 
 type Uploader interface {
-	HandleExecutable(ctx context.Context, elfRef *pfelf.Reference, fileID libpf.FileID) error
+	HandleExecutable(elfRef *pfelf.Reference, fileID libpf.FileID)
 }

--- a/symbolication/uploader.go
+++ b/symbolication/uploader.go
@@ -1,8 +1,6 @@
 package symbolication
 
 import (
-	"context"
-
 	"github.com/elastic/otel-profiling-agent/libpf"
 	"github.com/elastic/otel-profiling-agent/libpf/pfelf"
 )
@@ -11,10 +9,7 @@ var _ Uploader = (*NoopUploader)(nil)
 
 type NoopUploader struct{}
 
-func (n *NoopUploader) HandleExecutable(_ context.Context, _ *pfelf.Reference,
-	_ libpf.FileID) error {
-	return nil
-}
+func (n *NoopUploader) HandleExecutable(_ *pfelf.Reference, _ libpf.FileID) {}
 
 func NewNoopUploader() Uploader {
 	return &NoopUploader{}


### PR DESCRIPTION
this is useful for testing locally and getting a good grasp at how many binaries we will be uploading when the local symbol upload feature is active

pfelf: refactor debug links support

add OpenDebugBuildID method and refactor OpenDebugLink method so that it's compatible with https://sourceware.org/gdb/current/onlinedocs/gdb.html/Separate-Debug-Files.html

this is the way that gdb searches for separate debug executables, so it should hopefully be more exhaustive.

as a side note, -dbgsym packages on ubuntu (for example, openssh-server-dbgsym) only download symbols to the build ID directory /usr/lib/debug/.build-id/ (and not the debug link directories), hence the new method also maximizes the chance to find potential debug symbols on ubuntu.

uploader: more exhaustive search for debug symbols

take opportunity of the newly added functions in pfelf to look for debug symbols in /usr/lib/debug/.build-id and more generally in /usr/lib/debug, which maximizes our chances to find debug symbols locally.

symbolication: refactor uploader

multiple small refactors to hopefully make the code more robust:
* remove the context in HandleExecutable(), now it should be clearer which parts are synchrounous, which part are async, and what timeouts apply to each section
* do symbol extraction (via objcopy) asynchronously, we don't strictly need it to be synchronous so we do it async which should hopefully reduce the impact on the process manager run frequency
* group extraction and upload in the same function (to which the async timeout of 10s by default applies)

in the future it might make sense to make this timeout configurable

uploader: avoid failing if golang binary does not have build ID

some golang executables don't have a build ID, so we don't want to fail if we can't get the GNU build ID for those executables

uploader: modify interface to not return error

logging an error when the uploader fails to handle an executable turned out to be relatively noisy, so we modify the interface to no longer return an error, and we log.Debugf errors we encounter in the uploader

pfelf: fix debug link path

