### PR TITLE
reporter: compact pprofs

### DIFF
--- a/reporter/datadog_reporter.go
+++ b/reporter/datadog_reporter.go
@@ -525,6 +525,8 @@ func (r *DatadogReporter) getPprofProfile() (profile *pprofile.Profile,
 	profile.DurationNanos = int64(endTS - startTS)
 	profile.TimeNanos = int64(startTS)
 
+	profile = profile.Compact()
+
 	return profile, startTS, endTS
 }
 


### PR DESCRIPTION
compact pprof, which removes duplicate locations, and shrinks the size of uploaded pprof files

