### PR TITLE
release: build multi-arch docker image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          file: Dockerfile.release
+          file: docker/Dockerfile.release
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,8 @@ jobs:
 
   release:
     env:
+      REGISTRY: ghcr.io
+      IMAGE_NAME: datadog/otel-profiling-agent
       RELEASE_VERSION: ${{ github.ref_name }}
     needs: build
     name: Release
@@ -19,7 +21,28 @@ jobs:
     permissions:
       actions: read
       contents: write
+      packages: write
     steps:
+      - name: Check out
+        uses: actions/checkout@v4
+      - name: Setup buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        env:
+          DOCKER_METADATA_ANNOTATIONS_LEVELS: manifest,index
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          annotations: |
+            org.opencontainers.image.description=The Datadog OpenTelemetry Profiling Agent is a full-host profiler that collects and sends profiling data to Datadog
+            org.opencontainers.image.vendor=Datadog
       - name: Download artifacts
         uses: actions/download-artifact@v4
       - name: Create assets
@@ -35,3 +58,12 @@ jobs:
           omitBody:  true
           draft: true
           tag: ${{ env.RELEASE_VERSION }}
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.release
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          annotations: ${{ steps.meta.outputs.annotations }}

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,0 +1,16 @@
+# syntax=docker.io/docker/dockerfile:1.7-labs
+FROM ubuntu:24.04
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends binutils ca-certificates
+
+COPY --parents agent-** /tmp/
+
+RUN mv /tmp/agent-$(uname -p)/otel-profiling-agent /usr/local/bin/otel-profiling-agent \
+    && chmod +x /usr/local/bin/otel-profiling-agent \
+    && rm -rf /tmp/agent*
+
+RUN apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+CMD ["/usr/local/bin/otel-profiling-agent"]

--- a/docker/Dockerfile.release
+++ b/docker/Dockerfile.release
@@ -4,6 +4,7 @@ FROM ubuntu:24.04
 RUN apt-get update && \
     apt-get install -y --no-install-recommends binutils ca-certificates
 
+COPY docker/entrypoint.sh /entrypoint.sh
 COPY --parents agent-** /tmp/
 
 RUN mv /tmp/agent-$(uname -p)/otel-profiling-agent /usr/local/bin/otel-profiling-agent \
@@ -13,4 +14,5 @@ RUN mv /tmp/agent-$(uname -p)/otel-profiling-agent /usr/local/bin/otel-profiling
 RUN apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
+ENTRYPOINT ["/entrypoint.sh"]
 CMD ["/usr/local/bin/otel-profiling-agent"]

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,11 @@
+#! /usr/bin/env sh
+set -e
+
+# Wrapper to ensure debugfs is mounted
+
+# Mount debugfs if not already mounted
+if [ ! -d /sys/kernel/debug/tracing ]; then
+    mount -t debugfs none /sys/kernel/debug
+fi
+
+exec "$@"


### PR DESCRIPTION
Container image is published to: https://github.com/DataDog/otel-profiling-agent/pkgs/container/otel-profiling-agent

Tested locally and the agent is running just fine:
```
time="2024-08-12T15:15:44Z" level=info msg="Starting OTEL profiling agent nayef/dockerfile+a7538d1.10353767468 (revision head-a7538d1a, build timestamp 1723472983)"
```

Jira: https://datadoghq.atlassian.net/browse/PROF-10354
