### PR TITLE
uploads: update compression to zstd

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.22.2
 
 require (
 	cloud.google.com/go/compute/metadata v0.3.0
+	github.com/DataDog/zstd v1.5.7-0.20240809173922-01236a179a11
 	github.com/aws/aws-sdk-go-v2/config v1.27.21
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.16.8
 	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.17.1

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/AdamKorcz/go-118-fuzz-build v0.0.0-20230306123547-8075edf89bb0/go.mod
 github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 h1:UQHMgLO+TxOElx5B5HZ4hJQsoJ/PvUvKRhJHDQXO8P8=
 github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/DataDog/zstd v1.5.7-0.20240809173922-01236a179a11 h1:6YQbimbKhZdYzmxeK86+enPpwE1QzXD6txp5CkE5kI8=
+github.com/DataDog/zstd v1.5.7-0.20240809173922-01236a179a11/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/Microsoft/hcsshim v0.11.5 h1:haEcLNpj9Ka1gd3B3tAEs9CpE0c+1IhoL59w/exYU38=


### PR DESCRIPTION
Update compression to zstd for profile and symbol upload with the goal of reducing network traffic.

Since we're sending a multi-part attachment with a small event (metadata) and a large file (pprof/symbols), with our current backend implementation, it's preferable to only compress the large payload to reduce costs.

However, since handling a compressed file is only supported for profiles and not symbols, we:
* Compress the pprof file in zstd (previously gzip) for profiles.
* Compress the whole HTTP payload for symbols in zstd (previously gzip).

@DataDog/profiling-full-host 

https://datadoghq.atlassian.net/browse/PROF-10408
