### PR TITLE
github: fix workflow permissions error

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,11 +1,6 @@
-name: CI
+name: Common build
 
 on:
-  push:
-    branches: [main]
-  pull_request:
-    types: [opened, synchronize, reopened, labeled]
-    branches: ["**"]
   workflow_call:
 
 jobs:
@@ -244,52 +239,3 @@ jobs:
         with:
           name: agent-${{ matrix.os == 'arm-4core-linux-ubuntu24.04' && 'aarch64' || 'x86_64' }}
           path: otel-profiling-agent
-
-  publish:
-    env:
-      RELEASE_VERSION: ${{ github.event_name == 'pull_request' && 'dev-test' || 'dev' }}
-    if: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'publish-dev-test') )}}
-    name: Publish pre-release
-    needs: [build]
-    runs-on: ubuntu-24.04
-    permissions:
-      contents: write
-      packages: write
-    steps:
-      - name: Download artifacts
-        uses: actions/download-artifact@v4
-      - name: Create assets
-        run: |
-          tar czf otel-profiling-agent-${RELEASE_VERSION}-aarch64.tar.gz -C agent-aarch64 .
-          tar czf otel-profiling-agent-${RELEASE_VERSION}-x86_64.tar.gz -C agent-x86_64 .
-          sha256sum otel-profiling-agent-${RELEASE_VERSION}-aarch64.tar.gz otel-profiling-agent-${RELEASE_VERSION}-x86_64.tar.gz > sha256sums.txt
-      - name: Create or move previous dev tag
-        continue-on-error: true
-        uses: actions/github-script@v7
-        with:
-          script: |
-            github.rest.git.createRef({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              ref: 'refs/tags/${{ env.RELEASE_VERSION }}',
-              sha: context.sha
-            }).catch(err => {
-              if (err.status !== 422) throw err;
-              github.rest.git.updateRef({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                ref: 'tags/${{ env.RELEASE_VERSION }}',
-                sha: context.sha
-              })
-            });
-      - name: Create pre-release
-        uses: ncipollo/release-action@v1
-        with:
-          artifacts: "otel-profiling-agent-${{ env.RELEASE_VERSION }}-*.tar.gz,sha256sums.txt"
-          allowUpdates: true
-          removeArtifacts: true
-          omitBody:  true
-          omitDraftDuringUpdate: true
-          prerelease: true
-          draft: false
-          tag: ${{ env.RELEASE_VERSION }}

--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -1,0 +1,62 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
+    branches: ["**"]
+
+jobs:
+  build:
+    name: Build
+    uses: ./.github/workflows/build.yml
+
+  publish:
+    env:
+      RELEASE_VERSION: ${{ github.event_name == 'pull_request' && 'dev-test' || 'dev' }}
+    if: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'publish-dev-test') )}}
+    name: Publish pre-release
+    needs: [build]
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+      packages: write
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+      - name: Create assets
+        run: |
+          tar czf otel-profiling-agent-${RELEASE_VERSION}-aarch64.tar.gz -C agent-aarch64 .
+          tar czf otel-profiling-agent-${RELEASE_VERSION}-x86_64.tar.gz -C agent-x86_64 .
+          sha256sum otel-profiling-agent-${RELEASE_VERSION}-aarch64.tar.gz otel-profiling-agent-${RELEASE_VERSION}-x86_64.tar.gz > sha256sums.txt
+      - name: Create or move previous dev tag
+        continue-on-error: true
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.git.createRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: 'refs/tags/${{ env.RELEASE_VERSION }}',
+              sha: context.sha
+            }).catch(err => {
+              if (err.status !== 422) throw err;
+              github.rest.git.updateRef({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: 'tags/${{ env.RELEASE_VERSION }}',
+                sha: context.sha
+              })
+            });
+      - name: Create pre-release
+        uses: ncipollo/release-action@v1
+        with:
+          artifacts: "otel-profiling-agent-${{ env.RELEASE_VERSION }}-*.tar.gz,sha256sums.txt"
+          allowUpdates: true
+          removeArtifacts: true
+          omitBody:  true
+          omitDraftDuringUpdate: true
+          prerelease: true
+          draft: false
+          tag: ${{ env.RELEASE_VERSION }}


### PR DESCRIPTION
currently, the publish job, although not used at all by the release workflow, is imported as part of the build.yaml import (for the side effect of importing lint, tests and build jobs).

however, this is causing an issue since we switched the default permissions to contents/packages read instead of write. as the publish job requires the write permission, however, build.yaml is imported with the standard permissions, causing the following error:

The workflow is not valid. .github/workflows/release.yml (Line: 9, Col: 3): Error calling workflow 'DataDog/otel-profiling-agent/.github/workflows/build.yml@5d1ecca8fa1333159fd6eac689aec181057efc35'. The nested job 'publish' is requesting 'contents: write, packages: write', but is only allowed 'contents: read, packages: read'.

To fix this, we create a new workflow, pre-release, that contains the publish job, this way common build, lint, tests jobs can be imported by both release and pre-release without causing any issue

